### PR TITLE
FIX CVE-2020-8130

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,3 @@ if Dir.exist?(logstash_path) && use_logstash_source
   gem 'logstash-core', :path => "#{logstash_path}/logstash-core"
   gem 'logstash-core-plugin-api', :path => "#{logstash_path}/logstash-core-plugin-api"
 end
-
-if RUBY_VERSION == "1.9.3"
-  gem 'rake', '12.2.1'
-end

--- a/spec/integration/outputs/create_spec.rb
+++ b/spec/integration/outputs/create_spec.rb
@@ -27,12 +27,12 @@ describe "client create actions", :integration => true do
   end
 
   before :each do
-    @es = get_client
+    @client = get_client
     # Delete all templates first.
     # Clean OpenSearch of data before we start.
-    @es.indices.delete_template(:name => "*")
+    @client.indices.delete_template(:name => "*")
     # This can fail if there are no indexes, ignore failure.
-    @es.indices.delete(:index => "*") rescue nil
+    @client.indices.delete(:index => "*") rescue nil
   end
 
   context "when action => create" do
@@ -40,10 +40,10 @@ describe "client create actions", :integration => true do
       subject = get_es_output("create", "id123")
       subject.register
       subject.multi_receive([LogStash::Event.new("message" => "sample message here")])
-      @es.indices.refresh
+      @client.indices.refresh
       # Wait or fail until everything's indexed.
       Stud::try(3.times) do
-        r = @es.search(index: 'logstash-*')
+        r = @client.search(index: 'logstash-*')
         expect(r).to have_hits(1)
       end
     end

--- a/spec/integration/outputs/ingest_pipeline_spec.rb
+++ b/spec/integration/outputs/ingest_pipeline_spec.rb
@@ -40,11 +40,11 @@ describe "Ingest pipeline execution behavior", :integration => true do
     require "elasticsearch"
 
     # Clean OpenSearch of data before we start.
-    @es = get_client
-    @es.indices.delete_template(:name => "*")
+    @client = get_client
+    @client.indices.delete_template(:name => "*")
 
     # This can fail if there are no indexes, ignore failure.
-    @es.indices.delete(:index => "*") rescue nil
+    @client.indices.delete(:index => "*") rescue nil
 
     # delete existing ingest pipeline
     http_client.delete(ingest_url).call
@@ -53,22 +53,22 @@ describe "Ingest pipeline execution behavior", :integration => true do
     http_client.put(ingest_url, :body => apache_logs_pipeline, :headers => {"Content-Type" => "application/json" }).call
 
     #TODO: Use esclient
-    #@es.ingest.put_pipeline :id => 'apache_pipeline', :body => pipeline_defintion
+    #@client.ingest.put_pipeline :id => 'apache_pipeline', :body => pipeline_defintion
 
     subject.register
     subject.multi_receive([LogStash::Event.new("message" => '183.60.215.50 - - [01/Jun/2015:18:00:00 +0000] "GET /scripts/netcat-webserver HTTP/1.1" 200 182 "-" "Mozilla/5.0 (compatible; EasouSpider; +http://www.easou.com/search/spider.html)"')])
-    @es.indices.refresh
+    @client.indices.refresh
 
     #Wait or fail until everything's indexed.
     Stud::try(10.times) do
-      r = @es.search(index: 'logstash-*')
+      r = @client.search(index: 'logstash-*')
       expect(r).to have_hits(1)
       sleep(0.1)
     end
   end
 
   it "indexes using the proper pipeline" do
-    results = @es.search(:index => 'logstash-*', :q => "message:\"netcat\"")
+    results = @client.search(:index => 'logstash-*', :q => "message:\"netcat\"")
     expect(results).to have_hits(1)
     expect(results["hits"]["hits"][0]["_source"]["response"]).to eq("200")
     expect(results["hits"]["hits"][0]["_source"]["bytes"]).to eq("182")

--- a/spec/integration/outputs/metrics_spec.rb
+++ b/spec/integration/outputs/metrics_spec.rb
@@ -27,8 +27,8 @@ describe "metrics", :integration => true do
     require "elasticsearch"
 
     # Clean OpenSearch of data before we start.
-    @es = get_client
-    clean(@es)
+    @client = get_client
+    clean(@client)
     subject.register
   end
 

--- a/spec/integration/outputs/no_opensearch_on_startup_spec.rb
+++ b/spec/integration/outputs/no_opensearch_on_startup_spec.rb
@@ -31,10 +31,10 @@ describe "opensearch is down on startup", :integration => true do
     allow(Stud).to receive(:stoppable_sleep)
 
     # Clean OpenSearch of data before we start.
-    @es = get_client
-    @es.indices.delete_template(:name => "*")
-    @es.indices.delete(:index => "*")
-    @es.indices.refresh
+    @client = get_client
+    @client.indices.delete_template(:name => "*")
+    @client.indices.delete(:index => "*")
+    @client.indices.refresh
   end
 
   after :each do
@@ -46,8 +46,8 @@ describe "opensearch is down on startup", :integration => true do
     subject.register
     allow_any_instance_of(LogStash::Outputs::OpenSearch::HttpClient::Pool).to receive(:get_version).and_return(OpenSearchHelper.version)
     subject.multi_receive([event1, event2])
-    @es.indices.refresh
-    r = @es.search(index: 'logstash-*')
+    @client.indices.refresh
+    r = @client.search(index: 'logstash-*')
     expect(r).to have_hits(2)
   end
 
@@ -59,8 +59,8 @@ describe "opensearch is down on startup", :integration => true do
       allow_any_instance_of(LogStash::Outputs::OpenSearch::HttpClient::Pool).to receive(:get_version).and_return(OpenSearchHelper.version)
     end
     subject.multi_receive([event1, event2])
-    @es.indices.refresh
-    r = @es.search(index: 'logstash-*')
+    @client.indices.refresh
+    r = @client.search(index: 'logstash-*')
     expect(r).to have_hits(2)
   end
 

--- a/spec/integration/outputs/retry_spec.rb
+++ b/spec/integration/outputs/retry_spec.rb
@@ -57,10 +57,10 @@ describe "failures in bulk class expected behavior", :integration => true do
     allow(Stud).to receive(:stoppable_sleep)
 
     # Clean OpenSearch of data before we start.
-    @es = get_client
-    @es.indices.delete_template(:name => "*")
-    @es.indices.delete(:index => "*")
-    @es.indices.refresh
+    @client = get_client
+    @client.indices.delete_template(:name => "*")
+    @client.indices.delete(:index => "*")
+    @client.indices.refresh
   end
 
   after :each do
@@ -154,8 +154,8 @@ describe "failures in bulk class expected behavior", :integration => true do
     subject.multi_receive([invalid_event])
     subject.close
 
-    @es.indices.refresh
-    r = @es.search(index: 'logstash-*')
+    @client.indices.refresh
+    r = @client.search(index: 'logstash-*')
     expect(r).to have_hits(0)
   end
 
@@ -165,8 +165,8 @@ describe "failures in bulk class expected behavior", :integration => true do
     subject.register
     subject.multi_receive([event1])
     subject.close
-    @es.indices.refresh
-    r = @es.search(index: 'logstash-*')
+    @client.indices.refresh
+    r = @client.search(index: 'logstash-*')
     expect(r).to have_hits(1)
   end
 
@@ -175,8 +175,8 @@ describe "failures in bulk class expected behavior", :integration => true do
     subject.multi_receive([invalid_event, event1])
     subject.close
 
-    @es.indices.refresh
-    r = @es.search(index: 'logstash-*')
+    @client.indices.refresh
+    r = @client.search(index: 'logstash-*')
     expect(r).to have_hits(1)
   end
 end

--- a/spec/integration/outputs/templates_spec.rb
+++ b/spec/integration/outputs/templates_spec.rb
@@ -25,11 +25,11 @@ describe "index template expected behavior", :integration => true do
     require "elasticsearch"
 
     # Clean OpenSearch of data before we start.
-    @es = get_client
-    @es.indices.delete_template(:name => "*")
+    @client = get_client
+    @client.indices.delete_template(:name => "*")
 
     # This can fail if there are no indexes, ignore failure.
-    @es.indices.delete(:index => "*") rescue nil
+    @client.indices.delete(:index => "*") rescue nil
 
     subject.register
 
@@ -44,23 +44,23 @@ describe "index template expected behavior", :integration => true do
       LogStash::Event.new("geoip" => { "location" => [ 0.0, 0.0 ] })
     ])
 
-    @es.indices.refresh
+    @client.indices.refresh
 
     # Wait or fail until everything's indexed.
     Stud::try(20.times) do
-      r = @es.search(index: 'logstash-*')
+      r = @client.search(index: 'logstash-*')
       expect(r).to have_hits(8)
     end
   end
 
   it "permits phrase searching on string fields" do
-    results = @es.search(:q => "message:\"sample message\"")
+    results = @client.search(:q => "message:\"sample message\"")
     expect(results).to have_hits(1)
     expect(results["hits"]["hits"][0]["_source"]["message"]).to eq("sample message here")
   end
 
   it "numbers dynamically map to a numeric type and permit range queries" do
-    results = @es.search(:q => "somevalue:[5 TO 105]")
+    results = @client.search(:q => "somevalue:[5 TO 105]")
     expect(results).to have_hits(2)
 
     values = results["hits"]["hits"].collect { |r| r["_source"]["somevalue"] }
@@ -70,22 +70,22 @@ describe "index template expected behavior", :integration => true do
   end
 
   it "does not create .keyword field for top-level message field" do
-    results = @es.search(:q => "message.keyword:\"sample message here\"")
+    results = @client.search(:q => "message.keyword:\"sample message here\"")
     expect(results).to have_hits(0)
   end
 
   it "creates .keyword field for nested message fields" do
-    results = @es.search(:q => "somemessage.message.keyword:\"sample nested message here\"")
+    results = @client.search(:q => "somemessage.message.keyword:\"sample nested message here\"")
     expect(results).to have_hits(1)
   end
 
   it "creates .keyword field from any string field which is not_analyzed" do
-    results = @es.search(:q => "country.keyword:\"us\"")
+    results = @client.search(:q => "country.keyword:\"us\"")
     expect(results).to have_hits(1)
     expect(results["hits"]["hits"][0]["_source"]["country"]).to eq("us")
 
     # partial or terms should not work.
-    results = @es.search(:q => "country.keyword:\"u\"")
+    results = @client.search(:q => "country.keyword:\"u\"")
     expect(results).to have_hits(0)
   end
 
@@ -94,7 +94,7 @@ describe "index template expected behavior", :integration => true do
   end
 
   it "aggregate .keyword results correctly " do
-    results = @es.search(:body => { "aggregations" => { "my_agg" => { "terms" => { "field" => "country.keyword" } } } })["aggregations"]["my_agg"]
+    results = @client.search(:body => { "aggregations" => { "my_agg" => { "terms" => { "field" => "country.keyword" } } } })["aggregations"]["my_agg"]
     terms = results["buckets"].collect { |b| b["key"] }
 
     expect(terms).to include("us")

--- a/spec/opensearch_spec_helper.rb
+++ b/spec/opensearch_spec_helper.rb
@@ -36,7 +36,7 @@ module OpenSearchHelper
   end
 
   def field_properties_from_template(template_name, field)
-    template = get_template(@es, template_name)
+    template = get_template(@client, template_name)
     mappings = get_template_mappings(template)
     mappings["properties"][field]["properties"]
   end


### PR DESCRIPTION
### Description
There is an OS command injection vulnerability in Ruby Rake before 12.3.3 in Rake::FileList when supplying a filename that begins with the pipe character |. Though suggested remedy is to update to 12.3.3, we can remove this pinning since it was required only for Logstash 5.x.


### Issues Resolved
#10 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has documentation added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).