### PR TITLE
Support TLS Certificate

### DIFF
--- a/lib/logstash/plugin_mixins/opensearch/api_configs.rb
+++ b/lib/logstash/plugin_mixins/opensearch/api_configs.rb
@@ -66,6 +66,12 @@ module LogStash; module PluginMixins; module OpenSearch
         # Set the keystore password
         :keystore_password => { :validate => :password },
 
+        # Set the TLS Client certificate file
+        :tls_certificate => { :validate => :path },
+
+        # Private key file name
+        :tls_key => { :validate => :path },
+
         # This setting asks OpenSearch for the list of all cluster nodes and adds them to the hosts list.
         # Note: This will return ALL nodes with HTTP enabled (including master nodes!). If you use
         # this with master nodes, you probably want to disable HTTP on them by setting

--- a/spec/unit/outputs/opensearch_ssl_spec.rb
+++ b/spec/unit/outputs/opensearch_ssl_spec.rb
@@ -87,4 +87,93 @@ describe "SSL option" do
     end
 
   end
+
+  context "when using ssl with client certificates and key" do
+    let(:tls_certificate) { Stud::Temporary.file.path }
+    let(:tls_key) { Stud::Temporary.file.path }
+    before do
+      `openssl req -x509  -batch -nodes -newkey rsa:2048 -keyout #{tls_key} -out #{tls_certificate}`
+    end
+
+    after :each do
+      File.delete(tls_key)
+      File.delete(tls_certificate)
+      subject.close
+    end
+
+    subject do
+      require "logstash/outputs/opensearch"
+      settings = {
+        "hosts" => "node01",
+        "ssl" => true,
+        "tls_certificate" => tls_certificate,
+        "tls_key" => tls_key
+      }
+      next LogStash::Outputs::OpenSearch.new(settings)
+    end
+
+    it "should pass the tls certificate parameters to the OpenSearch client" do
+      expect(::Manticore::Client).to receive(:new) do |args|
+        expect(args[:ssl]).to include(:client_cert => tls_certificate, :client_key => tls_key)
+      end.and_call_original
+      subject.register
+    end
+
+  end
+
+  context "passing only tls certificate but missing the key" do
+    let(:tls_certificate) { Stud::Temporary.file.path }
+    let(:tls_key) { Stud::Temporary.file.path }
+    before do
+      `openssl req -x509  -batch -nodes -newkey rsa:2048 -keyout #{tls_key} -out #{tls_certificate}`
+    end
+
+    after :each do
+      File.delete(tls_key)
+      File.delete(tls_certificate)
+      subject.close
+    end
+
+    subject do
+      settings = {
+        "hosts" => "node01",
+        "ssl" => true,
+        "tls_certificate" => tls_certificate,
+      }
+      next LogStash::Outputs::OpenSearch.new(settings)
+    end
+
+    it "should not load plugin" do
+      expect { subject.register }.to raise_error(LogStash::ConfigurationError)
+    end
+  end
+
+  context "passing only tls key but missing the certificate" do
+    let(:tls_certificate) { Stud::Temporary.file.path }
+    let(:tls_key) { Stud::Temporary.file.path }
+    before do
+      `openssl req -x509  -batch -nodes -newkey rsa:2048 -keyout #{tls_key} -out #{tls_certificate}`
+    end
+
+    after :each do
+      File.delete(tls_key)
+      File.delete(tls_certificate)
+      subject.close
+    end
+
+    subject do
+      settings = {
+        "hosts" => "node01",
+        "ssl" => true,
+        "tls_key" => tls_key,
+      }
+      next LogStash::Outputs::OpenSearch.new(settings)
+    end
+
+    it "should not load plugin" do
+      expect { subject.register }.to raise_error(LogStash::ConfigurationError)
+    end
+  end
+
+
 end


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
Since OpenSearch supports TLS certificate authentication,
this plugin should support those mechanism as well.

### Issues Resolved
#30 

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [ ] New functionality has documentation added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).