### PR TITLE
Rename Content-Type

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -69,7 +69,7 @@ scripts/unit-test/docker-run.sh
 ```
 
 #### Run Integration Tests
-1. Tests against OpenSearch
+1. Tests against OpenSearch clusters.
 
 ```bash
 # Set up Environment variable for Docker to pull your test environment

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -69,7 +69,7 @@ scripts/unit-test/docker-run.sh
 ```
 
 #### Run Integration Tests
-1. Tests against OpenSearch clusters.
+1. Tests against OpenSearch
 
 ```bash
 # Set up Environment variable for Docker to pull your test environment

--- a/lib/logstash/outputs/opensearch/http_client/manticore_adapter.rb
+++ b/lib/logstash/outputs/opensearch/http_client/manticore_adapter.rb
@@ -11,7 +11,7 @@ require 'manticore'
 require 'cgi'
 
 module LogStash; module Outputs; class OpenSearch; class HttpClient;
-  DEFAULT_HEADERS = { "Content-Type" => "application/json" }
+  DEFAULT_HEADERS = { "content-type" => "application/json" }
   
   class ManticoreAdapter
     attr_reader :manticore, :logger

--- a/spec/integration/outputs/compressed_indexing_spec.rb
+++ b/spec/integration/outputs/compressed_indexing_spec.rb
@@ -67,7 +67,7 @@ describe "indexing with http_compression turned on", :integration => true do
 
   it "sets the correct content-encoding header and body is compressed" do
     expect(subject.client.pool.adapter.client).to receive(:send).
-      with(anything, anything, {:headers=>{"Content-Encoding"=>"gzip", "Content-Type"=>"application/json"}, :body => a_valid_gzip_encoded_string}).
+      with(anything, anything, {:headers=>{"Content-Encoding"=>"gzip", "content-type"=>"application/json"}, :body => a_valid_gzip_encoded_string}).
       and_call_original
     subject.multi_receive(events)
   end

--- a/spec/integration/outputs/index_spec.rb
+++ b/spec/integration/outputs/index_spec.rb
@@ -95,10 +95,10 @@ describe "indexing" do
     end
     
     it "sets the correct content-type header" do
-      expected_manticore_opts = {:headers => {"Content-Type" => "application/json"}, :body => anything}
+      expected_manticore_opts = {:headers => {"content-type" => "application/json"}, :body => anything}
       if secure
         expected_manticore_opts = {
-          :headers => {"Content-Type" => "application/json"}, 
+          :headers => {"content-type" => "application/json"},
           :body => anything, 
           :auth => {
             :user => user,

--- a/spec/integration/outputs/ingest_pipeline_spec.rb
+++ b/spec/integration/outputs/ingest_pipeline_spec.rb
@@ -50,7 +50,7 @@ describe "Ingest pipeline execution behavior", :integration => true do
     http_client.delete(ingest_url).call
 
     # register pipeline
-    http_client.put(ingest_url, :body => apache_logs_pipeline, :headers => {"Content-Type" => "application/json" }).call
+    http_client.put(ingest_url, :body => apache_logs_pipeline, :headers => {"content-type" => "application/json" }).call
 
     #TODO: Use esclient
     #@client.ingest.put_pipeline :id => 'apache_pipeline', :body => pipeline_defintion

--- a/spec/integration/outputs/parent_spec.rb
+++ b/spec/integration/outputs/parent_spec.rb
@@ -25,7 +25,7 @@ context "join field tests", :integration => true do
     let(:parent_relation) { "parent_type" }
     let(:child_relation) { "child_type" }
     let(:default_headers) {
-      {"Content-Type" => "application/json"}
+      {"content-type" => "application/json"}
     }
     subject { LogStash::Outputs::OpenSearch.new(config) }
 

--- a/spec/unit/outputs/opensearch/http_client/manticore_adapter_spec.rb
+++ b/spec/unit/outputs/opensearch/http_client/manticore_adapter_spec.rb
@@ -42,7 +42,7 @@ describe LogStash::Outputs::OpenSearch::HttpClient::ManticoreAdapter do
       
       expect(subject.manticore).to receive(:get).
         with(expected_uri.to_s, {
-          :headers => {"Content-Type" => "application/json"},
+          :headers => {"content-type" => "application/json"},
           :auth => {
             :user => user,
             :password => password,


### PR DESCRIPTION
Renaming Content-Type as content-type because to add IAM Authentication we will use AWS Signer for which all the headers needs to be in lower-case

**Reference:**
https://docs.aws.amazon.com/general/latest/gr/sigv4-signed-request-examples.html
Step 4 explains that the canonical header names should be in lower-case

**Acknowledgement**
I confirm that updating Content-Type as content-type will not break any existing functionality and there are no use cases where it should be in upper case