### PR TITLE
Backport to 1.1

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
   Unit-test:
     strategy:
       matrix:
-        logstash: [ "7.13.2" ]
+        logstash: [ "7.13.2", "7.13.4" ]
     name: Unit Test logstash-output-opensearch
     runs-on: ubuntu-latest
     env:
@@ -33,7 +33,7 @@ jobs:
   Integration-Test-OpenSearch:
     strategy:
       matrix:
-        logstash: [ "7.13.2" ]
+        logstash: [ "7.13.2", "7.13.4" ]
         opensearch: [ "1.0.0" ]
         secure: [ true, false ]
 
@@ -58,7 +58,7 @@ jobs:
   Integration-Test-OpenDistro:
     strategy:
       matrix:
-        logstash: [ "7.13.2" ]
+        logstash: [ "7.13.2", "7.13.4" ]
         opendistro: [ "1.13.2" ]
         secure: [ true, false ]
 

--- a/logstash-output-opensearch.gemspec
+++ b/logstash-output-opensearch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-opensearch'
-  s.version         = '1.0.0'
+  s.version         = '1.1.0'
 
   s.licenses        = ['Apache-2.0']
   s.summary         = "Stores logs in OpenSearch"


### PR DESCRIPTION
### Description
Backport https://github.com/opensearch-project/logstash-output-opensearch/pull/70 to 1.1 branch


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has documentation added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).