### PR TITLE
Adding basic_auth authentication

### DIFF
--- a/lib/logstash/outputs/opensearch/http_client/manticore_adapter.rb
+++ b/lib/logstash/outputs/opensearch/http_client/manticore_adapter.rb
@@ -18,6 +18,7 @@ module LogStash; module Outputs; class OpenSearch; class HttpClient;
   AWS_DEFAULT_REGION = 'us-east-1'
   AWS_IAM_AUTH_TYPE = "aws_iam"
   AWS_SERVICE = 'es'
+  BASIC_AUTH_TYPE = 'basic'
   DEFAULT_HEADERS = { "content-type" => "application/json" }
 
   AWSIAMCredential = Struct.new(
@@ -47,6 +48,8 @@ module LogStash; module Outputs; class OpenSearch; class HttpClient;
 
       if @type == AWS_IAM_AUTH_TYPE
         aws_iam_auth_initialization(options)
+      elsif @type == BASIC_AUTH_TYPE
+        basic_auth_initialization(options)
       end
 
       if options[:proxy]
@@ -76,12 +79,29 @@ module LogStash; module Outputs; class OpenSearch; class HttpClient;
       @credentials = Aws::CredentialProviderChain.new(credential_config).resolve
     end
 
+    def basic_auth_initialization(options)
+      set_user_password(options)
+    end
+
     def set_aws_region(region)
       @region = region
     end
 
     def get_aws_region()
       @region
+    end
+
+    def set_user_password(options)
+      @user = options[:auth_type]["user"]
+      @password = options[:auth_type]["password"]
+    end
+
+    def get_user()
+      @user
+    end
+
+    def get_password()
+      @password
     end
     
     # Transform the proxy option to a hash. Manticore's support for non-hash
@@ -122,6 +142,8 @@ module LogStash; module Outputs; class OpenSearch; class HttpClient;
           :password => CGI.unescape(url.password), 
           :eager => true 
         }
+      elsif @type == BASIC_AUTH_TYPE
+        add_basic_auth_to_params(params)
       end
 
       request_uri = format_url(url, path)
@@ -155,6 +177,14 @@ module LogStash; module Outputs; class OpenSearch; class HttpClient;
       aws_signer = Aws::Signers::V4.new(@credentials,  AWS_SERVICE, get_aws_region )
       signed_key =  aws_signer.sign(key)
       params[:headers] =  params[:headers].merge(signed_key.headers)
+    end
+
+    def add_basic_auth_to_params(params)
+      params[:auth] = {
+        :user => get_user(),
+        :password => get_password(),
+        :eager => true
+      }
     end
 
     # Returned urls from this method should be checked for double escaping.

--- a/spec/integration/outputs/index_spec.rb
+++ b/spec/integration/outputs/index_spec.rb
@@ -161,4 +161,41 @@ describe "indexing" do
     end
     it_behaves_like("an indexer", true)
   end
+
+  describe "a basic auth secured indexer", :secure_integration => true do
+    let(:options) { {
+      :auth_type => {
+        "type"=>"basic",
+        "user" => "admin",
+        "password" => "admin"}
+    } }
+    let(:user) {options[:auth_type]["user"]}
+    let(:password) {options[:auth_type]["password"]}
+    let(:es_url) {"https://integration:9200"}
+    let(:config) do
+      {
+        "hosts" => ["integration:9200"],
+        "auth_type" => {
+          "type"=>"basic",
+          "user" => user,
+          "password" => password},
+        "ssl" => true,
+        "ssl_certificate_verification" => false,
+        "index" => index
+      }
+    end
+    let(:http_client_options) do
+      {
+        :auth => {
+          :user => user,
+          :password => password
+        },
+        :ssl => {
+          :enabled => true,
+          :verify => false
+        }
+      }
+    end
+    it_behaves_like("an indexer", true)
+  end
 end


### PR DESCRIPTION
Signed-off-by: Naveen Tatikonda <navtat@amazon.com>

### Description
Adding basic_auth as a new authentication mechanism by also supporting existing Master credentials (user and password without auth_type). Also added, unit tests and integration tests to validate.

### Issues Resolved
https://github.com/opensearch-project/logstash-output-opensearch/issues/74

I tested this updated code with opensearch output configurations by taking the standard input and verified the message in the index:

- [x] With existing master credentials
- [x] With auth_type as "aws_iam" for AWS IAM credentials
- [x] With auth_type as "basic" for master credentials

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has documentation added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).