### PR TITLE
Adding optional parameters required for authentication inside auth_type

### DIFF
--- a/lib/logstash/outputs/opensearch/http_client/manticore_adapter.rb
+++ b/lib/logstash/outputs/opensearch/http_client/manticore_adapter.rb
@@ -15,6 +15,8 @@ require 'uri'
 module LogStash; module Outputs; class OpenSearch; class HttpClient;
   AWS_DEFAULT_PORT = 443
   AWS_DEFAULT_PROFILE = 'default'
+  AWS_DEFAULT_PROFILE_CREDENTIAL_RETRY = 0
+  AWS_DEFAULT_PROFILE_CREDENTIAL_TIMEOUT = 1
   AWS_DEFAULT_REGION = 'us-east-1'
   AWS_IAM_AUTH_TYPE = "aws_iam"
   AWS_SERVICE = 'es'
@@ -65,10 +67,10 @@ module LogStash; module Outputs; class OpenSearch; class HttpClient;
     def aws_iam_auth_initialization(options)
       aws_access_key_id =  options[:auth_type]["aws_access_key_id"] || nil
       aws_secret_access_key = options[:auth_type]["aws_secret_access_key"] || nil
-      session_token = options[:session_token] || nil
-      profile = options[:profile] || AWS_DEFAULT_PROFILE
-      instance_cred_retries = options[:instance_profile_credentials_retries] || 0
-      instance_cred_timeout = options[:instance_profile_credentials_timeout] || 1
+      session_token = options[:auth_type]["session_token"] || nil
+      profile = options[:auth_type]["profile"] || AWS_DEFAULT_PROFILE
+      instance_cred_retries = options[:auth_type]["instance_profile_credentials_retries"] || AWS_DEFAULT_PROFILE_CREDENTIAL_RETRY
+      instance_cred_timeout = options[:auth_type]["instance_profile_credentials_timeout"] || AWS_DEFAULT_PROFILE_CREDENTIAL_TIMEOUT
       region = options[:auth_type]["region"] || AWS_DEFAULT_REGION
       set_aws_region(region)
 


### PR DESCRIPTION
Signed-off-by: Naveen Tatikonda <navtat@amazon.com>

### Description
Adding optional parameters required for aws_iam authentication inside auth_type

### Issues Resolved
https://github.com/opensearch-project/logstash-output-opensearch/issues/83

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has documentation added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).