### PR TITLE
Update copyright license header

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@
     - [Documentation Changes](#documentation-changes)
     - [Contributing Code](#contributing-code)
 - [Developer Certificate of Origin](#developer-certificate-of-origin)
+- [License Headers](#license-headers)
 - [Review Process](#review-process)
 
 ## Contributing to logstash-output-opensearch
@@ -83,6 +84,31 @@ Each commit must include a DCO which looks like this
 Signed-off-by: Jane Smith <jane.smith@email.com>
 ```
 You may type this line on your own when writing your commit messages.  However, if your user.name and user.email are set in your git configs, you can use `-s` or `– – signoff` to add the `Signed-off-by` line to the end of the commit message.
+
+## License Headers
+
+New files in your code contributions should contain the following license header. If you are modifying existing files with license headers, or including new files that already have license headers, do not remove or modify them without guidance.
+
+### Java
+
+```
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+```
+
+### Python
+```
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+```
+
+### Shell
+```
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+```
 
 ## Review Process
 

--- a/release/docker/build-docker-multi-arch.sh
+++ b/release/docker/build-docker-multi-arch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 # This is intended to be run the plugin's root directory. `release/docker`


### PR DESCRIPTION
Signed-off-by: Naveen Tatikonda <navtat@amazon.com>

### Description
Update Copyright license header in CONTRIBUTING.md and other file

### Issues Resolved
https://github.com/opensearch-project/logstash-output-opensearch/issues/51

### Check List
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).