### PR TITLE
Adding Signing key path to gemspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ vendor/
 /.idea/
 /dockerfiles/bin/
 /dockerfiles/.env
+gem-private_key.pem
+

--- a/logstash-output-opensearch.gemspec
+++ b/logstash-output-opensearch.gemspec
@@ -7,6 +7,8 @@
 # Modifications Copyright OpenSearch Contributors. See
 # GitHub history for details.
 
+signing_key_path = "gem-private_key.pem"
+
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-opensearch'
   s.version         = '1.2.0'
@@ -27,7 +29,10 @@ Gem::Specification.new do |s|
   # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
 
-  s.cert_chain  = ['certs/opensearch-rubygems.pem']
+  if $PROGRAM_NAME.end_with?("gem") && ARGV == ["build", __FILE__] && File.exist?(signing_key_path)
+    s.signing_key = signing_key_path
+    s.cert_chain  = ['certs/opensearch-rubygems.pem']
+  end
 
   # Special flag to let us know this is actually a logstash plugin
   s.metadata = {


### PR DESCRIPTION
Signed-off-by: Naveen Tatikonda <navtat@amazon.com>

### Description
Adding signing key path to gemspec

### Issues Resolved
https://github.com/opensearch-project/logstash-output-opensearch/issues/100

### Check List
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).