### PR TITLE
Add dependency to opensearch-ruby

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,7 @@ jobs:
   Integration-Test-OpenSearch:
     strategy:
       matrix:
-        logstash: [ "7.13.2", "7.13.4" ]
+        logstash: [ "7.15.2", "7.14.2" ]
         opensearch: [ "1.2.0" ]
         secure: [ true, false ]
 

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -18,7 +18,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@master
         with:
-          args: --accept=200,403,429  "**/*.html" "**/*.md" "**/*.txt" "**/*.json" --exclude "https://github.com/\[your*" --exclude-mail
+          args: --accept=200,403,429  **/*.html **/*.md **/*.txt **/*.json --exclude https://github.com/\[your* --exclude-mail
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Fail if there were link errors

--- a/logstash-output-opensearch.gemspec
+++ b/logstash-output-opensearch.gemspec
@@ -1,3 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-opensearch'
   s.version         = '1.2.0'
@@ -37,4 +46,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'flores'
   s.add_development_dependency 'cabin', ['~> 0.6']
+  s.add_development_dependency 'opensearch-ruby'
 end

--- a/spec/integration/outputs/compressed_indexing_spec.rb
+++ b/spec/integration/outputs/compressed_indexing_spec.rb
@@ -33,8 +33,8 @@ describe "indexing with http_compression turned on", :integration => true do
   }
   subject { LogStash::Outputs::OpenSearch.new(config) }
 
-  let(:es_url) { "http://#{get_host_port}" }
-  let(:index_url) {"#{es_url}/#{index}"}
+  let(:opensearch_url) { "http://#{get_host_port}" }
+  let(:index_url) {"#{opensearch_url}/#{index}"}
   let(:http_client_options) { {} }
   let(:http_client) do
     Manticore::Client.new(http_client_options)
@@ -49,7 +49,7 @@ describe "indexing with http_compression turned on", :integration => true do
     it "ships events" do
       subject.multi_receive(events)
 
-      http_client.post("#{es_url}/_refresh").call
+      http_client.post("#{opensearch_url}/_refresh").call
 
       response = http_client.get("#{index_url}/_count?q=*")
       result = LogStash::Json.load(response.body)

--- a/spec/integration/outputs/create_spec.rb
+++ b/spec/integration/outputs/create_spec.rb
@@ -12,7 +12,7 @@ require_relative "../../../spec/opensearch_spec_helper"
 describe "client create actions", :integration => true do
   require "logstash/outputs/opensearch"
 
-  def get_es_output(action, id, version=nil, version_type=nil)
+  def get_output(action, id, version=nil, version_type=nil)
     settings = {
       "manage_template" => true,
       "index" => "logstash-create",
@@ -37,7 +37,7 @@ describe "client create actions", :integration => true do
 
   context "when action => create" do
     it "should create new documents with or without id" do
-      subject = get_es_output("create", "id123")
+      subject = get_output("create", "id123")
       subject.register
       subject.multi_receive([LogStash::Event.new("message" => "sample message here")])
       @client.indices.refresh
@@ -49,27 +49,27 @@ describe "client create actions", :integration => true do
     end
 
     it "should allow default (internal) version" do
-      subject = get_es_output("create", "id123", 43)
+      subject = get_output("create", "id123", 43)
       subject.register
     end
 
     it "should allow internal version" do
-      subject = get_es_output("create", "id123", 43, "internal")
+      subject = get_output("create", "id123", 43, "internal")
       subject.register
     end
 
     it "should not allow external version" do
-      subject = get_es_output("create", "id123", 43, "external")
+      subject = get_output("create", "id123", 43, "external")
       expect { subject.register }.to raise_error(LogStash::ConfigurationError)
     end
 
     it "should not allow external_gt version" do
-      subject = get_es_output("create", "id123", 43, "external_gt")
+      subject = get_output("create", "id123", 43, "external_gt")
       expect { subject.register }.to raise_error(LogStash::ConfigurationError)
     end
 
     it "should not allow external_gte version" do
-      subject = get_es_output("create", "id123", 43, "external_gte")
+      subject = get_output("create", "id123", 43, "external_gte")
       expect { subject.register }.to raise_error(LogStash::ConfigurationError)
     end
   end

--- a/spec/integration/outputs/delete_spec.rb
+++ b/spec/integration/outputs/delete_spec.rb
@@ -66,7 +66,7 @@ describe "Versioned delete", :integration => true do
       expect(r['_source']['message']).to eq('foo')
 
       subject.multi_receive([LogStash::Event.new("my_id" => id, "my_action" => "delete", "message" => "foo", "my_version" => 100)])
-      expect { es.get(:index => 'logstash-delete', :type => doc_type, :id => id, :refresh => true) }.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
+      expect { es.get(:index => 'logstash-delete', :type => doc_type, :id => id, :refresh => true) }.to raise_error(OpenSearch::Transport::Transport::Errors::NotFound)
     end
   end
 end

--- a/spec/integration/outputs/index_spec.rb
+++ b/spec/integration/outputs/index_spec.rb
@@ -62,8 +62,8 @@ describe "indexing" do
   let(:events) { event_count.times.map { event }.to_a }
   subject { LogStash::Outputs::OpenSearch.new(config) }
   
-  let(:es_url) { "http://#{get_host_port}" }
-  let(:index_url) {"#{es_url}/#{index}"}
+  let(:opensearch_url) { "http://#{get_host_port}" }
+  let(:index_url) {"#{opensearch_url}/#{index}"}
   let(:http_client_options) { {} }
   let(:http_client) do
     Manticore::Client.new(http_client_options)
@@ -78,7 +78,7 @@ describe "indexing" do
     it "ships events" do
       subject.multi_receive(events)
 
-      http_client.post("#{es_url}/_refresh").call
+      http_client.post("#{opensearch_url}/_refresh").call
 
       response = http_client.get("#{index_url}/_count?q=*")
       result = LogStash::Json.load(response.body)
@@ -135,7 +135,7 @@ describe "indexing" do
   describe "a secured indexer", :secure_integration => true do
     let(:user) { "admin" }
     let(:password) { "admin" }
-    let(:es_url) {"https://integration:9200"}
+    let(:opensearch_url) {"https://integration:9200"}
     let(:config) do
       {
         "hosts" => ["integration:9200"],
@@ -170,7 +170,7 @@ describe "indexing" do
     } }
     let(:user) {options[:auth_type]["user"]}
     let(:password) {options[:auth_type]["password"]}
-    let(:es_url) {"https://integration:9200"}
+    let(:opensearch_url) {"https://integration:9200"}
     let(:config) do
       {
         "hosts" => ["integration:9200"],

--- a/spec/integration/outputs/index_version_spec.rb
+++ b/spec/integration/outputs/index_version_spec.rb
@@ -13,15 +13,15 @@ require "logstash/outputs/opensearch"
 describe "Versioned indexing", :integration => true do
   require "logstash/outputs/opensearch"
 
-  let(:es) { get_client }
+  let(:client) { get_client }
 
   before :each do
     # Delete all templates first.
     # Clean OpenSearch of data before we start.
-    es.indices.delete_template(:name => "*")
+    client.indices.delete_template(:name => "*")
     # This can fail if there are no indexes, ignore failure.
-    es.indices.delete(:index => "*") rescue nil
-    es.indices.refresh
+    client.indices.delete(:index => "*") rescue nil
+    client.indices.refresh
   end
 
   context "when index only" do
@@ -46,11 +46,11 @@ describe "Versioned indexing", :integration => true do
 
       it "should default to OpenSearch version" do
         subject.multi_receive([LogStash::Event.new("my_id" => "123", "message" => "foo")])
-        r = es.get(:index => 'logstash-index', :type => doc_type, :id => "123", :refresh => true)
+        r = client.get(:index => 'logstash-index', :type => doc_type, :id => "123", :refresh => true)
         expect(r["_version"]).to eq(1)
         expect(r["_source"]["message"]).to eq('foo')
         subject.multi_receive([LogStash::Event.new("my_id" => "123", "message" => "foobar")])
-        r2 = es.get(:index => 'logstash-index', :type => doc_type, :id => "123", :refresh => true)
+        r2 = client.get(:index => 'logstash-index', :type => doc_type, :id => "123", :refresh => true)
         expect(r2["_version"]).to eq(2)
         expect(r2["_source"]["message"]).to eq('foobar')
       end
@@ -74,7 +74,7 @@ describe "Versioned indexing", :integration => true do
       it "should respect the external version" do
         id = "ev1"
         subject.multi_receive([LogStash::Event.new("my_id" => id, "my_version" => "99", "message" => "foo")])
-        r = es.get(:index => 'logstash-index', :type => doc_type, :id => id, :refresh => true)
+        r = client.get(:index => 'logstash-index', :type => doc_type, :id => id, :refresh => true)
         expect(r["_version"]).to eq(99)
         expect(r["_source"]["message"]).to eq('foo')
       end
@@ -82,12 +82,12 @@ describe "Versioned indexing", :integration => true do
       it "should ignore non-monotonic external version updates" do
         id = "ev2"
         subject.multi_receive([LogStash::Event.new("my_id" => id, "my_version" => "99", "message" => "foo")])
-        r = es.get(:index => 'logstash-index', :type => doc_type, :id => id, :refresh => true)
+        r = client.get(:index => 'logstash-index', :type => doc_type, :id => id, :refresh => true)
         expect(r["_version"]).to eq(99)
         expect(r["_source"]["message"]).to eq('foo')
 
         subject.multi_receive([LogStash::Event.new("my_id" => id, "my_version" => "98", "message" => "foo")])
-        r2 = es.get(:index => 'logstash-index', :type => doc_type, :id => id, :refresh => true)
+        r2 = client.get(:index => 'logstash-index', :type => doc_type, :id => id, :refresh => true)
         expect(r2["_version"]).to eq(99)
         expect(r2["_source"]["message"]).to eq('foo')
       end
@@ -95,12 +95,12 @@ describe "Versioned indexing", :integration => true do
       it "should commit monotonic external version updates" do
         id = "ev3"
         subject.multi_receive([LogStash::Event.new("my_id" => id, "my_version" => "99", "message" => "foo")])
-        r = es.get(:index => 'logstash-index', :type => doc_type, :id => id, :refresh => true)
+        r = client.get(:index => 'logstash-index', :type => doc_type, :id => id, :refresh => true)
         expect(r["_version"]).to eq(99)
         expect(r["_source"]["message"]).to eq('foo')
 
         subject.multi_receive([LogStash::Event.new("my_id" => id, "my_version" => "100", "message" => "foo")])
-        r2 = es.get(:index => 'logstash-index', :type => doc_type, :id => id, :refresh => true)
+        r2 = client.get(:index => 'logstash-index', :type => doc_type, :id => id, :refresh => true)
         expect(r2["_version"]).to eq(100)
         expect(r2["_source"]["message"]).to eq('foo')
       end

--- a/spec/integration/outputs/ingest_pipeline_spec.rb
+++ b/spec/integration/outputs/ingest_pipeline_spec.rb
@@ -37,8 +37,6 @@ describe "Ingest pipeline execution behavior", :integration => true do
 
   before :each do
     # Delete all templates first.
-    require "elasticsearch"
-
     # Clean OpenSearch of data before we start.
     @client = get_client
     @client.indices.delete_template(:name => "*")

--- a/spec/integration/outputs/metrics_spec.rb
+++ b/spec/integration/outputs/metrics_spec.rb
@@ -24,8 +24,6 @@ describe "metrics", :integration => true do
   let(:document_level_metrics) { subject.instance_variable_get(:@document_level_metrics) }
 
   before :each do
-    require "elasticsearch"
-
     # Clean OpenSearch of data before we start.
     @client = get_client
     clean(@client)

--- a/spec/integration/outputs/no_opensearch_on_startup_spec.rb
+++ b/spec/integration/outputs/no_opensearch_on_startup_spec.rb
@@ -27,7 +27,6 @@ describe "opensearch is down on startup", :integration => true do
 
   before :each do
     # Delete all templates first.
-    require "elasticsearch"
     allow(Stud).to receive(:stoppable_sleep)
 
     # Clean OpenSearch of data before we start.

--- a/spec/integration/outputs/retry_spec.rb
+++ b/spec/integration/outputs/retry_spec.rb
@@ -53,7 +53,6 @@ describe "failures in bulk class expected behavior", :integration => true do
 
   before :each do
     # Delete all templates first.
-    require "elasticsearch"
     allow(Stud).to receive(:stoppable_sleep)
 
     # Clean OpenSearch of data before we start.

--- a/spec/integration/outputs/sniffer_spec.rb
+++ b/spec/integration/outputs/sniffer_spec.rb
@@ -15,9 +15,9 @@ require "socket"
 describe "pool sniffer", :integration => true do
   let(:logger) { Cabin::Channel.get }
   let(:adapter) { LogStash::Outputs::OpenSearch::HttpClient::ManticoreAdapter.new(logger) }
-  let(:es_host) { get_host_port.split(":").first }
+  let(:opensearch_host) { get_host_port.split(":").first }
   let(:es_port) { get_host_port.split(":").last }
-  let(:es_ip) { IPSocket.getaddress(es_host) }
+  let(:opensearch_ip) { IPSocket.getaddress(opensearch_host) }
   let(:initial_urls) { [::LogStash::Util::SafeURI.new("http://#{get_host_port}")] }
   let(:options) do
     {

--- a/spec/integration/outputs/templates_spec.rb
+++ b/spec/integration/outputs/templates_spec.rb
@@ -21,8 +21,6 @@ describe "index template expected behavior", :integration => true do
   end
 
   before :each do
-    # Delete all templates first.
-    require "elasticsearch"
 
     # Clean OpenSearch of data before we start.
     @client = get_client

--- a/spec/integration/outputs/update_spec.rb
+++ b/spec/integration/outputs/update_spec.rb
@@ -12,7 +12,7 @@ require_relative "../../../spec/opensearch_spec_helper"
 describe "Update actions without scripts", :integration => true do
   require "logstash/outputs/opensearch"
 
-  def get_es_output( options={} )
+  def get_output( options={} )
     settings = {
       "manage_template" => true,
       "index" => "logstash-update",
@@ -40,20 +40,20 @@ describe "Update actions without scripts", :integration => true do
   end
 
   it "should fail without a document_id" do
-    subject = get_es_output
+    subject = get_output
     expect { subject.register }.to raise_error(LogStash::ConfigurationError)
   end
 
   context "when update only" do
     it "should not create new document" do
-      subject = get_es_output({ 'document_id' => "456" } )
+      subject = get_output({ 'document_id' => "456" } )
       subject.register
       subject.multi_receive([LogStash::Event.new("message" => "sample message here")])
       expect {@client.get(:index => 'logstash-update', :type => doc_type, :id => "456", :refresh => true)}.to raise_error(OpenSearch::Transport::Transport::Errors::NotFound)
     end
 
     it "should update existing document" do
-      subject = get_es_output({ 'document_id' => "123" })
+      subject = get_output({ 'document_id' => "123" })
       subject.register
       subject.multi_receive([LogStash::Event.new("message" => "updated message here")])
       r = @client.get(:index => 'logstash-update', :type => doc_type, :id => "123", :refresh => true)
@@ -63,7 +63,7 @@ describe "Update actions without scripts", :integration => true do
     # The es ruby client treats the data field differently. Make sure this doesn't
     # raise an exception
     it "should update an existing document that has a 'data' field" do
-      subject = get_es_output({ 'document_id' => "123" })
+      subject = get_output({ 'document_id' => "123" })
       subject.register
       subject.multi_receive([LogStash::Event.new("data" => "updated message here", "message" => "foo")])
       r = @client.get(:index => 'logstash-update', :type => doc_type, :id => "123", :refresh => true)
@@ -72,27 +72,27 @@ describe "Update actions without scripts", :integration => true do
     end
 
     it "should allow default (internal) version" do
-      subject = get_es_output({ 'document_id' => "123", "version" => "99" })
+      subject = get_output({ 'document_id' => "123", "version" => "99" })
       subject.register
     end
 
     it "should allow internal version" do
-      subject = get_es_output({ 'document_id' => "123", "version" => "99", "version_type" => "internal" })
+      subject = get_output({ 'document_id' => "123", "version" => "99", "version_type" => "internal" })
       subject.register
     end
 
     it "should not allow external version" do
-      subject = get_es_output({ 'document_id' => "123", "version" => "99", "version_type" => "external" })
+      subject = get_output({ 'document_id' => "123", "version" => "99", "version_type" => "external" })
       expect { subject.register }.to raise_error(LogStash::ConfigurationError)
     end
 
     it "should not allow external_gt version" do
-      subject = get_es_output({ 'document_id' => "123", "version" => "99", "version_type" => "external_gt" })
+      subject = get_output({ 'document_id' => "123", "version" => "99", "version_type" => "external_gt" })
       expect { subject.register }.to raise_error(LogStash::ConfigurationError)
     end
 
     it "should not allow external_gte version" do
-      subject = get_es_output({ 'document_id' => "123", "version" => "99", "version_type" => "external_gte" })
+      subject = get_output({ 'document_id' => "123", "version" => "99", "version_type" => "external_gte" })
       expect { subject.register }.to raise_error(LogStash::ConfigurationError)
     end
 
@@ -100,7 +100,7 @@ describe "Update actions without scripts", :integration => true do
 
   context "when update with upsert" do
     it "should create new documents with provided upsert" do
-      subject = get_es_output({ 'document_id' => "456", 'upsert' => '{"message": "upsert message"}' })
+      subject = get_output({ 'document_id' => "456", 'upsert' => '{"message": "upsert message"}' })
       subject.register
       subject.multi_receive([LogStash::Event.new("message" => "sample message here")])
       r = @client.get(:index => 'logstash-update', :type => doc_type, :id => "456", :refresh => true)
@@ -108,7 +108,7 @@ describe "Update actions without scripts", :integration => true do
     end
 
     it "should create new documents with event/doc as upsert" do
-      subject = get_es_output({ 'document_id' => "456", 'doc_as_upsert' => true })
+      subject = get_output({ 'document_id' => "456", 'doc_as_upsert' => true })
       subject.register
       subject.multi_receive([LogStash::Event.new("message" => "sample message here")])
       r = @client.get(:index => 'logstash-update', :type => doc_type, :id => "456", :refresh => true)
@@ -116,7 +116,7 @@ describe "Update actions without scripts", :integration => true do
     end
 
     it "should fail on documents with event/doc as upsert at external version" do
-      subject = get_es_output({ 'document_id' => "456", 'doc_as_upsert' => true, 'version' => 999, "version_type" => "external" })
+      subject = get_output({ 'document_id' => "456", 'doc_as_upsert' => true, 'version' => 999, "version_type" => "external" })
       expect { subject.register }.to raise_error(LogStash::ConfigurationError)
     end
   end

--- a/spec/integration/outputs/update_spec.rb
+++ b/spec/integration/outputs/update_spec.rb
@@ -49,7 +49,7 @@ describe "Update actions without scripts", :integration => true do
       subject = get_es_output({ 'document_id' => "456" } )
       subject.register
       subject.multi_receive([LogStash::Event.new("message" => "sample message here")])
-      expect {@client.get(:index => 'logstash-update', :type => doc_type, :id => "456", :refresh => true)}.to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
+      expect {@client.get(:index => 'logstash-update', :type => doc_type, :id => "456", :refresh => true)}.to raise_error(OpenSearch::Transport::Transport::Errors::NotFound)
     end
 
     it "should update existing document" do

--- a/spec/opensearch_spec_helper.rb
+++ b/spec/opensearch_spec_helper.rb
@@ -9,7 +9,7 @@
 
 require_relative './spec_helper'
 
-require 'elasticsearch'
+require 'opensearch'
 
 require 'json'
 require 'cabin'
@@ -24,7 +24,7 @@ module OpenSearchHelper
   end
 
   def get_client
-    Elasticsearch::Client.new(:hosts => [get_host_port])
+    OpenSearch::Client.new(:hosts => [get_host_port])
   end
 
   def doc_type


### PR DESCRIPTION
### Description
* Use OpenSearch::Client instead of Elasticsearch.
* Update CI to test last two minor release.

### Issues Resolved
#55 

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has documentation added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).