### PR TITLE
Enable template management with new _index_template endpoint

### DIFF
--- a/lib/logstash/outputs/opensearch.rb
+++ b/lib/logstash/outputs/opensearch.rb
@@ -150,6 +150,12 @@ class LogStash::Outputs::OpenSearch < LogStash::Outputs::Base
   # the "logstash" template (i.e. removing all customized settings)
   config :template_overwrite, :validate => :boolean, :default => false
 
+  # The legacy_template option will use the old /_template
+      # path for creating index templates.
+      # It will also construct the ilm configurations for the template in a manner
+      # which is compatible with legacy templates
+      mod.config :legacy_template, :validate => :boolean, :default => true
+    
   # The version to use for indexing. Use sprintf syntax like `%{my_version}` to use a field value here.
   config :version, :validate => :string
 

--- a/lib/logstash/outputs/opensearch.rb
+++ b/lib/logstash/outputs/opensearch.rb
@@ -151,10 +151,10 @@ class LogStash::Outputs::OpenSearch < LogStash::Outputs::Base
   config :template_overwrite, :validate => :boolean, :default => false
 
   # The legacy_template option will use the old /_template
-      # path for creating index templates.
-      # It will also construct the ilm configurations for the template in a manner
-      # which is compatible with legacy templates
-      mod.config :legacy_template, :validate => :boolean, :default => true
+  # path for creating index templates.
+  # It will also construct the ilm configurations for the template in a manner
+  # which is compatible with legacy templates
+  config :legacy_template, :validate => :boolean, :default => true
     
   # The version to use for indexing. Use sprintf syntax like `%{my_version}` to use a field value here.
   config :version, :validate => :string

--- a/lib/logstash/outputs/opensearch/http_client.rb
+++ b/lib/logstash/outputs/opensearch/http_client.rb
@@ -75,7 +75,7 @@ module LogStash; module Outputs; class OpenSearch;
     end
 
     def legacy_template
-      client_settings.fetch(:legacy)
+      client_settings.fetch(:legacy_template)
     end
     
     def template_install(name, template, force=false)

--- a/lib/logstash/outputs/opensearch/http_client.rb
+++ b/lib/logstash/outputs/opensearch/http_client.rb
@@ -74,6 +74,10 @@ module LogStash; module Outputs; class OpenSearch;
       }
     end
 
+    def legacy_template
+      client_settings.fetch(:legacy)
+    end
+    
     def template_install(name, template, force=false)
       if template_exists?(name) && !force
         @logger.debug("Found existing OpenSearch template, skipping template management", name: name)
@@ -379,11 +383,19 @@ module LogStash; module Outputs; class OpenSearch;
     end
 
     def template_exists?(name)
-      exists?("/#{template_endpoint}/#{name}")
+      if legacy_template
+        exists?("/_template/#{name}")
+      else
+        exists?("/_index_template/#{name}")
+      end
     end
 
     def template_put(name, template)
-      path = "#{template_endpoint}/#{name}"
+      if legacy_template
+        path = "_template/#{name}"
+      else
+        path = "_index_template/#{name}"
+      end
       logger.info("Installing OpenSearch template", name: name)
       @pool.put(path, nil, LogStash::Json.dump(template))
     end

--- a/lib/logstash/outputs/opensearch/http_client_builder.rb
+++ b/lib/logstash/outputs/opensearch/http_client_builder.rb
@@ -18,7 +18,8 @@ module LogStash; module Outputs; class OpenSearch;
         :pool_max_per_route => params["pool_max_per_route"],
         :check_connection_timeout => params["validate_after_inactivity"],
         :http_compression => params["http_compression"],
-        :headers => params["custom_headers"] || {}
+        :headers => params["custom_headers"] || {},
+        :legacy => params["legacy_template"]
       }
       
       client_settings[:proxy] = params["proxy"] if params["proxy"]


### PR DESCRIPTION
### Description
This adds a new switch called legacy_template which is boolean (default true), when set to false changes the http endpoint that is hit when managing index templates (changes from _template to _index_template)

### Issues Resolved
#12 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has documentation added
- [ ] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).