### PR TITLE
Use absolute path for template_endpoint.

### DIFF
--- a/lib/logstash/outputs/opensearch/http_client.rb
+++ b/lib/logstash/outputs/opensearch/http_client.rb
@@ -379,7 +379,7 @@ module LogStash; module Outputs; class OpenSearch;
     end
 
     def template_exists?(name)
-      exists?("/#{template_endpoint}/#{name}")
+      exists?("#{template_endpoint}/#{name}")
     end
 
     def template_put(name, template)
@@ -391,7 +391,7 @@ module LogStash; module Outputs; class OpenSearch;
     def template_endpoint
       # TODO: Check Version < 7.8 and use index template for >= 7.8 & OpenSearch
       # https://opensearch.org/docs/opensearch/index-templates/
-      '_template'
+      '/_template'
     end
 
     # check whether rollover alias already exists


### PR DESCRIPTION
### Description
Use absolute path for template_endpoint.

### Issues Resolved
Fixes https://github.com/opensearch-project/logstash-output-opensearch/issues/124

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has documentation added
- [ ] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).