### PR TITLE
Bump logstash version to 7.17.1

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
   Unit-test:
     strategy:
       matrix:
-        logstash: [ "7.15.2", "7.16.3" ]
+        logstash: [ "7.16.3", "7.17.1" ]
     name: Unit Test logstash-output-opensearch
     runs-on: ubuntu-latest
     env:
@@ -33,7 +33,7 @@ jobs:
   Integration-Test-OpenSearch:
     strategy:
       matrix:
-        logstash: [ "7.15.2", "7.16.3" ]
+        logstash: [ "7.16.3", "7.17.1" ]
         opensearch: [ "1.2.1" ]
         secure: [ true, false ]
 
@@ -58,7 +58,7 @@ jobs:
   Integration-Test-OpenDistro:
     strategy:
       matrix:
-        logstash: [ "7.15.2", "7.16.3" ]
+        logstash: [ "7.16.3", "7.17.1" ]
         opendistro: [ "1.13.3" ]
         secure: [ true, false ]
 


### PR DESCRIPTION
Signed-off-by: Naveen Tatikonda <navtat@amazon.com>

### Description
Bumping up logstash version to 7.17.1

### Check List
- [x] All tests pass
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).