### PR TITLE
Use absolute path for template endpoint

### DIFF
--- a/lib/logstash/outputs/opensearch/http_client.rb
+++ b/lib/logstash/outputs/opensearch/http_client.rb
@@ -383,7 +383,7 @@ module LogStash; module Outputs; class OpenSearch;
     end
 
     def template_put(name, template)
-      path = "#{template_endpoint}/#{name}"
+      path = "/#{template_endpoint}/#{name}"
       logger.info("Installing OpenSearch template", name: name)
       @pool.put(path, nil, LogStash::Json.dump(template))
     end

--- a/spec/unit/outputs/opensearch/http_client_spec.rb
+++ b/spec/unit/outputs/opensearch/http_client_spec.rb
@@ -157,7 +157,7 @@ describe LogStash::Outputs::OpenSearch::HttpClient do
     }
 
     it "should call index template" do
-      expect(subject.pool).to receive(:put).with("_template/#{template_name}", nil, anything).and_return(get_response)
+      expect(subject.pool).to receive(:put).with("/_template/#{template_name}", nil, anything).and_return(get_response)
       subject.template_put(template_name, template)
     end
   end


### PR DESCRIPTION
### Description
Use absolute path for template endpoint ('/_template' instead of '_template')

### Issues Resolved
Fixes #124 
Fixes #144
Resolves this error installing template:
`[2022-06-08T10:02:44,587][ERROR][logstash.outputs.opensearch][devicelogs_http_input] Failed to install template {:message=>"bad component(expected absolute path component): _template/<template name>", :exception=>URI::InvalidComponentError,  ...`

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has documentation added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).