### PR TITLE
Update opensearch-ruby dependency to pin major version as 1.0

### DIFF
--- a/logstash-output-opensearch.gemspec
+++ b/logstash-output-opensearch.gemspec
@@ -52,5 +52,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'flores'
   s.add_development_dependency 'cabin', ['~> 0.6']
-  s.add_development_dependency 'opensearch-ruby'
+  s.add_development_dependency 'opensearch-ruby', '~> 1'
 end


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
opensearch-ruby 2.0 has breaking changes. Hence, update opensearch-ruby to use only from 1.x release.

### Issues Resolved


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has documentation added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).