### PR TITLE
Make ci compatible with os2.x

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         logstash: [ "7.16.3", "7.17.1" ]
-        opensearch: [ "1.2.1" ]
+        opensearch: [ "1.3.4", "2.1.0" ]
         secure: [ true, false ]
 
     name: Integration Test logstash-output-opensearch against OpenSearch

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,7 +1,5 @@
 ARG LOGSTASH_VERSION
 FROM docker.elastic.co/logstash/logstash-oss:${LOGSTASH_VERSION}
-USER root
-RUN apt-get update && apt-get install -y python
 USER logstash
 COPY --chown=logstash:logstash Gemfile /usr/share/plugins/plugin/Gemfile
 COPY --chown=logstash:logstash *.gemspec VERSION* version* /usr/share/plugins/plugin/

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,5 +1,7 @@
 ARG LOGSTASH_VERSION
 FROM docker.elastic.co/logstash/logstash-oss:${LOGSTASH_VERSION}
+USER root
+RUN apt-get update && apt-get install -y python
 USER logstash
 COPY --chown=logstash:logstash Gemfile /usr/share/plugins/plugin/Gemfile
 COPY --chown=logstash:logstash *.gemspec VERSION* version* /usr/share/plugins/plugin/

--- a/scripts/logstash-run.sh
+++ b/scripts/logstash-run.sh
@@ -16,7 +16,7 @@ wait_for_es() {
     [[ $count -eq 0 ]] && exit 1
     sleep 20
   done
-  echo $(curl -s $SERVICE_URL | python -c "import sys, json; print(json.load(sys.stdin)['version']['number'])")
+  echo $(curl -s $SERVICE_URL | grep -oP '"number"[^"]+"\K[^"]+')
 }
 
 if [[ "$SECURE_INTEGRATION" == "true" ]]; then

--- a/spec/integration/outputs/compressed_indexing_spec.rb
+++ b/spec/integration/outputs/compressed_indexing_spec.rb
@@ -59,7 +59,11 @@ describe "indexing with http_compression turned on", :integration => true do
       response = http_client.get("#{index_url}/_search?q=*&size=1000")
       result = LogStash::Json.load(response.body)
       result["hits"]["hits"].each do |doc|
-        expect(doc["_type"]).to eq(type)
+        if OpenSearchHelper.check_version?("< 2")
+          expect(doc["_type"]).to eq(type)
+        else
+          expect(doc).not_to include("_type")
+        end
         expect(doc["_index"]).to eq(index)
       end
     end

--- a/spec/integration/outputs/compressed_indexing_spec.rb
+++ b/spec/integration/outputs/compressed_indexing_spec.rb
@@ -59,7 +59,9 @@ describe "indexing with http_compression turned on", :integration => true do
       response = http_client.get("#{index_url}/_search?q=*&size=1000")
       result = LogStash::Json.load(response.body)
       result["hits"]["hits"].each do |doc|
-        if OpenSearchHelper.check_version?("< 2")
+        # FIXME This checks for OpenSearch 1.x or OpenDistro which has version 7.10.x
+        # need a cleaner way to check this.
+        if OpenSearchHelper.check_version?("< 2") || OpenSearchHelper.check_version?("> 7")
           expect(doc["_type"]).to eq(type)
         else
           expect(doc).not_to include("_type")

--- a/spec/integration/outputs/index_spec.rb
+++ b/spec/integration/outputs/index_spec.rb
@@ -88,7 +88,11 @@ describe "indexing" do
       response = http_client.get("#{index_url}/_search?q=*&size=1000")
       result = LogStash::Json.load(response.body)
       result["hits"]["hits"].each do |doc|
-        expect(doc["_type"]).to eq(type)
+        if OpenSearchHelper.check_version?("< 2")
+          expect(doc["_type"]).to eq(type)
+        else
+          expect(doc).not_to include("_type")
+        end
         expect(doc["_index"]).to eq(index)
       end
     end

--- a/spec/integration/outputs/index_spec.rb
+++ b/spec/integration/outputs/index_spec.rb
@@ -88,7 +88,9 @@ describe "indexing" do
       response = http_client.get("#{index_url}/_search?q=*&size=1000")
       result = LogStash::Json.load(response.body)
       result["hits"]["hits"].each do |doc|
-        if OpenSearchHelper.check_version?("< 2")
+        # FIXME This checks for OpenSearch 1.x or OpenDistro which has version 7.10.x
+        # need a cleaner way to check this.
+        if OpenSearchHelper.check_version?("< 2") || OpenSearchHelper.check_version?("> 7")
           expect(doc["_type"]).to eq(type)
         else
           expect(doc).not_to include("_type")

--- a/spec/integration/outputs/parent_spec.rb
+++ b/spec/integration/outputs/parent_spec.rb
@@ -10,7 +10,7 @@
 require_relative "../../../spec/opensearch_spec_helper"
 require "logstash/outputs/opensearch"
 
-context "join field tests", :integration => true do
+context "join field tests", :integration => true && OpenSearchHelper.check_version?("<2") do
 
   shared_examples "a join field based parent indexer" do
     let(:index) { 10.times.collect { rand(10).to_s }.join("") }

--- a/spec/opensearch_spec_helper.rb
+++ b/spec/opensearch_spec_helper.rb
@@ -49,6 +49,16 @@ module OpenSearchHelper
     RSpec.configuration.filter[:version]
   end
 
+  def self.check_version?(*requirement)
+    version = self.version
+    if version.nil? || version.empty?
+      puts "version tag isn't set. Returning false from 'check_version?`."
+      return false
+    end
+    release_version = Gem::Version.new(version).release
+    Gem::Requirement.new(requirement).satisfied_by?(release_version)
+  end
+
   RSpec::Matchers.define :have_hits do |expected|
     match do |actual|
       expected == actual['hits']['total']['value']


### PR DESCRIPTION
### Description
Fix the integration tests to work with OpenSearch 2.x and add OpenSearch 2.1.0 in the CI test matrix.
Also update the OpenSearch 1.x version in CI from 1.2.1 to 1.3.4

### Issues Resolved
https://github.com/opensearch-project/logstash-output-opensearch/issues/148

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has documentation added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).