### PR TITLE
Adding a config to skip_healthcheck

### DIFF
--- a/lib/logstash/outputs/opensearch.rb
+++ b/lib/logstash/outputs/opensearch.rb
@@ -200,6 +200,13 @@ class LogStash::Outputs::OpenSearch < LogStash::Outputs::Base
   # here like `pipeline => "%{INGEST_PIPELINE}"`
   config :pipeline, :validate => :string, :default => nil
 
+  # If enabled, skip the GET request to the Healthcheck endpoint to get the server version.
+  # The HEAD request is still done to check if the server is alive. 
+  config :skip_healthcheck, :validate => :boolean, :default => false
+
+  # The OpenSearch server major version to use when it's not available from the Healthcheck endpoint.
+  config :default_server_major_version, :validate => :number, :default => 2
+
   attr_reader :client
   attr_reader :default_index
   attr_reader :default_template_name

--- a/lib/logstash/outputs/opensearch.rb
+++ b/lib/logstash/outputs/opensearch.rb
@@ -200,12 +200,8 @@ class LogStash::Outputs::OpenSearch < LogStash::Outputs::Base
   # here like `pipeline => "%{INGEST_PIPELINE}"`
   config :pipeline, :validate => :string, :default => nil
 
-  # If enabled, skip the GET request to the Healthcheck endpoint to get the server version.
-  # The HEAD request is still done to check if the server is alive. 
-  config :skip_healthcheck, :validate => :boolean, :default => false
-
   # The OpenSearch server major version to use when it's not available from the Healthcheck endpoint.
-  config :default_server_major_version, :validate => :number, :default => 2
+  config :default_server_major_version, :validate => :number
 
   attr_reader :client
   attr_reader :default_index

--- a/lib/logstash/outputs/opensearch/http_client.rb
+++ b/lib/logstash/outputs/opensearch/http_client.rb
@@ -329,7 +329,6 @@ module LogStash; module Outputs; class OpenSearch;
         :resurrect_delay => options[:resurrect_delay],
         :url_normalizer => self.method(:host_to_url),
         :metric => options[:metric],
-        :skip_healthcheck => options[:skip_healthcheck],
         :default_server_major_version => options[:default_server_major_version]
       }
       pool_options[:scheme] = self.scheme if self.scheme

--- a/lib/logstash/outputs/opensearch/http_client.rb
+++ b/lib/logstash/outputs/opensearch/http_client.rb
@@ -328,7 +328,9 @@ module LogStash; module Outputs; class OpenSearch;
         :healthcheck_path => options[:healthcheck_path],
         :resurrect_delay => options[:resurrect_delay],
         :url_normalizer => self.method(:host_to_url),
-        :metric => options[:metric]
+        :metric => options[:metric],
+        :skip_healthcheck => options[:skip_healthcheck],
+        :default_server_major_version => options[:default_server_major_version]
       }
       pool_options[:scheme] = self.scheme if self.scheme
 

--- a/lib/logstash/outputs/opensearch/http_client_builder.rb
+++ b/lib/logstash/outputs/opensearch/http_client_builder.rb
@@ -26,7 +26,9 @@ module LogStash; module Outputs; class OpenSearch;
       common_options = {
         :client_settings => client_settings,
         :metric => params["metric"],
-        :resurrect_delay => params["resurrect_delay"]
+        :resurrect_delay => params["resurrect_delay"],
+        :skip_healthcheck => params["skip_healthcheck"],
+        :default_server_major_version => params["default_server_major_version"]
       }
 
       if params["sniffing"]

--- a/lib/logstash/outputs/opensearch/http_client_builder.rb
+++ b/lib/logstash/outputs/opensearch/http_client_builder.rb
@@ -27,7 +27,6 @@ module LogStash; module Outputs; class OpenSearch;
         :client_settings => client_settings,
         :metric => params["metric"],
         :resurrect_delay => params["resurrect_delay"],
-        :skip_healthcheck => params["skip_healthcheck"],
         :default_server_major_version => params["default_server_major_version"]
       }
 


### PR DESCRIPTION
Signed-off-by: Deep Datta <deedatta@amazon.com>

### Description
Add a skip_healthcheck config, which is false by default. When set to true it will not send a GET request to the healthcheck endpoint. However it will still send the HEAD request to make sure the node is alive.
To get a version number in that scenario, add another config default_server_major_version which is 2 by default denoting OpenSearch 2.x, but can be changed by the user.

### Issues Resolved
[Add a config to skip doing a GET on the healthcheck endpoint #165](https://github.com/opensearch-project/logstash-output-opensearch/issues/165)

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has documentation added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).