### PR TITLE
Add release workflows

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,35 +2,34 @@ name: Draft Release
 
 on:
   push:
-    branches: 
-      - add-release-workflows
+    tags:
+      - "*"
 
 jobs:
   draft_release:
     runs-on: ubuntu-latest
-    # permissions:
-    #   id-token: write
-    #   contents: write
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
-      # - name: Configure AWS credentials
-      #   uses: aws-actions/configure-aws-credentials@v1
-      #   with:
-      #     role-to-assume: ${{ secrets.GET_SECRET_IAM_ROLE }}
-      #     aws-region: us-east-1
-      # - name: Download signing key
-      #   run: | 
-      #     aws secretsmanager get-secret-value --secret-id jenkins-opensearchproject-rubygems-private-key --query SecretString --output text > gem-private_key.pem
+          ruby-version: jruby
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.GET_SECRET_IAM_ROLE }}
+          aws-region: us-east-1
+      - name: Download signing key
+        run: | 
+          aws secretsmanager get-secret-value --secret-id jenkins-opensearchproject-rubygems-private-key --query SecretString --output text > gem-private_key.pem
       - name: Build and package gem artifact
         run: |
           gem build logstash-output-opensearch.gemspec
-          mkdir dist
-          mv logstash-output-opensearch-*.gem dist/
+          mkdir dist && mv logstash-output-opensearch-*.gem dist/
           tar -cvf artifacts.tar.gz dist
       - name: Draft a release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,41 @@
+name: Draft Release
+
+on:
+  push:
+    branches: 
+      - add-release-workflows
+
+jobs:
+  draft_release:
+    runs-on: ubuntu-latest
+    # permissions:
+    #   id-token: write
+    #   contents: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+      # - name: Configure AWS credentials
+      #   uses: aws-actions/configure-aws-credentials@v1
+      #   with:
+      #     role-to-assume: ${{ secrets.GET_SECRET_IAM_ROLE }}
+      #     aws-region: us-east-1
+      # - name: Download signing key
+      #   run: | 
+      #     aws secretsmanager get-secret-value --secret-id jenkins-opensearchproject-rubygems-private-key --query SecretString --output text > gem-private_key.pem
+      - name: Build and package gem artifact
+        run: |
+          gem build logstash-output-opensearch.gemspec
+          mkdir dist
+          mv logstash-output-opensearch-*.gem dist/
+          tar -cvf artifacts.tar.gz dist
+      - name: Draft a release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          generate_release_notes: true
+          files: |
+            artifacts.tar.gz

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -35,6 +35,6 @@ The release process is standard across repositories in this org and is run by a 
 
 1. Create a tag, e.g. 1.0.0, and push it to this GitHub repository.
 1. The [release-drafter.yml](.github/workflows/release-drafter.yml) will be automatically kicked off and a draft release will be created.
-1. This draft release triggers the [jenkins release workflow](https://build.ci.opensearch.org/job/spring-data-opensearch-release) as a As a result of which the logstash-output-plugin is released on [rubygems.org](https://rubygems.org/gems/logstash-output-opensearch). Please note that the release workflow is triggered only if created release is in draft state.
+1. This draft release triggers the [jenkins release workflow](https://build.ci.opensearch.org/job/logstash-ouput-opensearch-release) as a As a result of which the logstash-output-plugin is released on [rubygems.org](https://rubygems.org/gems/logstash-output-opensearch). Please note that the release workflow is triggered only if created release is in draft state.
 1. Once the above release workflow is successful, the drafted release on GitHub is published automatically.
 1. Increment "version" in [logstash-output-opensearch.gemspec](./logstash-output-opensearch.gemspec) to the next iteration, e.g. 1.0.1.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,4 +33,8 @@ Repositories create consistent release labels, such as `v1.0.0`, `v1.1.0` and `v
 
 The release process is standard across repositories in this org and is run by a release manager volunteering from amongst [MAINTAINERS](MAINTAINERS.md).
 
-TODO
+1. Create a tag, e.g. 1.0.0, and push it to this GitHub repository.
+1. The [release-drafter.yml](.github/workflows/release-drafter.yml) will be automatically kicked off and a draft release will be created.
+1. This draft release triggers the [jenkins release workflow](https://build.ci.opensearch.org/job/spring-data-opensearch-release) as a As a result of which the logstash-output-plugin is released on [rubygems.org](https://rubygems.org/gems/logstash-output-opensearch). Please note that the release workflow is triggered only if created release is in draft state.
+1. Once the above release workflow is successful, the drafted release on GitHub is published automatically.
+1. Increment "version" in [logstash-output-opensearch.gemspec](./logstash-output-opensearch.gemspec) to the next iteration, e.g. 1.0.1.

--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -1,0 +1,12 @@
+lib = library(identifier: 'jenkins@1.4.2', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
+
+standardReleasePipelineWithGenericTrigger(
+    tokenIdCredential: 'jenkins-logstash-output-opensearch-generic-webhook-token',
+    causeString: 'A tag was cut on opensearch-project/logstash-output-opensearch repository causing this workflow to run',
+    downloadReleaseAsset: true,
+    publishRelease: true) {
+        publishToRubyGems(apiKeyCredentialId: 'jenkins-logstash-output-opensearch-api-key')
+    }


### PR DESCRIPTION
### Description
This change add release workflows for logstash-output-opensearch plugin that is released on rubygems.
See https://github.com/opensearch-project/opensearch-build/issues/1234 for more details about end to end process.

The secrets role has been added to this repo as well as new api key required has been generated. I'll be adding the webhook once this PR is merged.
Thanks!

### Issues Resolved
closes https://github.com/opensearch-project/opensearch-build/issues/3139

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has documentation added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).