### PR TITLE
Add override image, ruby version and upgrade jenkins lib

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -4,9 +4,13 @@ lib = library(identifier: 'jenkins@1.5.4', retriever: modernSCM([
 ]))
 
 standardReleasePipelineWithGenericTrigger(
+    overrideDockerImage: 'opensearchstaging/ci-runner:release-centos7-clients-v2.1',
     tokenIdCredential: 'jenkins-logstash-output-opensearch-generic-webhook-token',
     causeString: 'A tag was cut on opensearch-project/logstash-output-opensearch repository causing this workflow to run',
     downloadReleaseAsset: true,
     publishRelease: true) {
-        publishToRubyGems(apiKeyCredentialId: 'jenkins-logstash-output-opensearch-api-key')
+        publishToRubyGems(
+            rubyVersion: 'jruby-9.3.0.0',
+            apiKeyCredentialId: 'jenkins-logstash-output-opensearch-api-key'
+            )
     }


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
The current docker image did not have jruby installed which is used by this project. Hence we added it and published a new version of docker image. Also the new lib adds the support to specify the jruby version which is used to install gem and verify if the gem is signed or not.

Related PRs: https://github.com/opensearch-project/opensearch-build/pull/3169
https://github.com/opensearch-project/opensearch-build-libraries/pull/119

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has documentation added
- [ ] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).