### PR TITLE
Fixes CODEOWNERS by putting all on a single line.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,2 @@
 # This should match the list of maintainers in MAINTAINERS.md
-* @asifsmohammed
-* @dlvenable
-* @oeyh
+* @asifsmohammed @dlvenable @oeyh


### PR DESCRIPTION
### Description

Fixes the `CODEOWNERS` file by putting all users on a single line.

See: https://github.com/opensearch-project/logstash-output-opensearch/pull/203#discussion_r1142562128

### Issues Resolved


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has documentation added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).