### PR TITLE
Fix: remove warning message on cluster UUID retrieval failure with AOSS.

### DIFF
--- a/lib/logstash/plugin_mixins/opensearch/common.rb
+++ b/lib/logstash/plugin_mixins/opensearch/common.rb
@@ -87,6 +87,7 @@ module LogStash; module PluginMixins; module OpenSearch
 
     def discover_cluster_uuid
       return unless defined?(plugin_metadata)
+      return if params && params['auth_type'] && params['auth_type']['service_name'] == "aoss" # AOSS doesn't support GET /
       cluster_info = client.get('/')
       plugin_metadata.set(:cluster_uuid, cluster_info['cluster_uuid'])
     rescue => e

--- a/release-notes/logstash-output-opensearch-release-notes-2.0.1.md
+++ b/release-notes/logstash-output-opensearch-release-notes-2.0.1.md
@@ -1,12 +1,16 @@
 ## Version 2.0.1 Release Notes
+
 Compatible with OpenSearch 1.3+, 2.0+
 
 ### Bug Fixes
+
 * Fix a gzip compression issue when sending partial bulk requests (#183)
 
 ### Documentation
+
 * Update the OpenSearch documentation website link for this plugin (#178)
 * Updated MAINTAINERS.md format. (#185)
 
 ### Infrastructure
+
 * Add release workflows (#188)

--- a/release-notes/logstash-output-opensearch-release-notes-2.0.2.md
+++ b/release-notes/logstash-output-opensearch-release-notes-2.0.2.md
@@ -3,8 +3,10 @@
 Compatible with OpenSearch 1.3+, 2.0+
 
 ### Bug Fixes
+
 * Encode body before signing to match manticore adapter encoding. ([#207](https://github.com/opensearch-project/logstash-output-opensearch/issues/207))
 
 ### Documentation
+
 * Baselines the MAINTAINERS.md and CODEOWNERS files. ([#196](https://github.com/opensearch-project/logstash-output-opensearch/issues/196))
 

--- a/release-notes/logstash-output-opensearch-release-notes-next.md
+++ b/release-notes/logstash-output-opensearch-release-notes-next.md
@@ -1,0 +1,11 @@
+## Version 2.0.3 Release Notes
+
+Compatible with OpenSearch 1.3+, 2.0+
+
+### Bug Fixes
+
+* Fix warning retrieving cluster UUID with Amazon OpenSearch Serverless (#237)
+
+### Documentation
+
+### Infrastructure

--- a/spec/unit/outputs/opensearch_spec.rb
+++ b/spec/unit/outputs/opensearch_spec.rb
@@ -776,6 +776,30 @@ describe LogStash::Outputs::OpenSearch do
       expect(logger).to have_received(:error).with(/Unable to retrieve OpenSearch cluster uuid/i, anything)
     end
 
+    context 'with iam auth' do
+      context 'es' do
+        let(:options) { { 'hosts' => '127.0.0.1:9999', 'auth_type' => { 'service_name' => 'es' } } }
+        it "logs inability to retrieve uuid" do
+          allow(subject).to receive(:install_template)
+          subject.register
+          subject.send :wait_for_successful_connection
+    
+          expect(logger).to have_received(:error).with(/Unable to retrieve OpenSearch cluster uuid/i, anything)
+        end
+      end
+
+      context 'aoss' do
+        let(:options) { { 'hosts' => '127.0.0.1:9999', 'auth_type' => { 'service_name' => 'aoss' } } }
+        it "does not attempt to retrieve uuid" do
+          allow(subject).to receive(:install_template)
+          subject.register
+          subject.send :wait_for_successful_connection
+
+          expect(logger).to_not have_received(:error)
+        end
+      end
+    end
+
     it "logs template install failure" do
       allow(subject).to receive(:discover_cluster_uuid)
       subject.register


### PR DESCRIPTION
### Description

AOSS does not support GET, don't attempt to retrieve cluster UUID

### Issues Resolved

Closes https://github.com/opensearch-project/logstash-output-opensearch/issues/186

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has documentation added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).