### PR TITLE
Adds dblock as a maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the list of maintainers in MAINTAINERS.md
-* @asifsmohammed @dlvenable @oeyh
+* @dblock @asifsmohammed @dlvenable @oeyh

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,11 +5,12 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 ## Current Maintainers
 
 
-| Maintainer              | GitHub ID                                   | Affiliation |
-| ----------------------- | ------------------------------------------- | ----------- |
-| Asif Sohail Mohammed | [asifsmohammed](https://github.com/asifsmohammed)     | Amazon      |
-| David Venable        | [dlvenable](https://github.com/dlvenable)             | Amazon      |
-| Hai Yan              | [oeyh](https://github.com/oeyh)                       | Amazon      |
+| Maintainer               | GitHub ID                                           | Affiliation |
+| ------------------------ | --------------------------------------------------- | ----------- |
+| Daniel "dB." Doubrovkine | [dblock](https://github.com/dblock)                 | Amazon      |
+| Asif Sohail Mohammed     | [asifsmohammed](https://github.com/asifsmohammed)   | Amazon      |
+| David Venable            | [dlvenable](https://github.com/dlvenable)           | Amazon      |
+| Hai Yan                  | [oeyh](https://github.com/oeyh)                     | Amazon      |
 
 
 


### PR DESCRIPTION
### Description

Adding @dblock as a maintainer as voted upon by the current maintainers.

He has made a [number of contributions](https://github.com/opensearch-project/logstash-output-opensearch/pulls?q=is%3Apr+is%3Aclosed+author%3Adblock) including fixing a bug (#217) that affected sigV4 signing.

Additionally, he has been active in the issues, PR reviews, and recent releases.

### Issues Resolved

N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has documentation added
- [ ] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).