### PR TITLE
Build against aws-sdk-core.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Starting in 2.0.0, the aws sdk version is bumped to v3. In order for all other A
 /usr/share/logstash/bin/logstash-plugin install --version 2.0.0 logstash-output-opensearch
 ```
 ## ECS Compatibility
-[Elastic Common Schema(ECS)](https://www.elastic.co/guide/en/ecs/current/index.html]) compatibility for V8 was added in 1.3.0. For more details on ECS support refer to this [documentation](docs/ecs_compatibility.md).
+[Elastic Common Schema(ECS)](https://www.elastic.co/guide/en/ecs/current/index.html) compatibility for V8 was added in 1.3.0. For more details on ECS support refer to this [documentation](docs/ecs_compatibility.md).
 
 
 ## Code of Conduct

--- a/logstash-output-opensearch.gemspec
+++ b/logstash-output-opensearch.gemspec
@@ -11,7 +11,7 @@ signing_key_path = "gem-private_key.pem"
 
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-opensearch'
-  s.version         = '2.0.3'
+  s.version         = '2.1.0'
 
   s.licenses        = ['Apache-2.0']
   s.summary         = "Stores logs in OpenSearch"
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'stud', ['>= 0.0.17', '~> 0.0']
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.0'
-  s.add_runtime_dependency 'aws-sdk', '~> 3'
+  s.add_runtime_dependency 'aws-sdk-core', '~> 3'
   s.add_runtime_dependency 'json', '>= 2.3.0', '~> 2'
 
   s.add_development_dependency 'logstash-codec-plain'

--- a/release-notes/logstash-output-opensearch-release-notes-next.md
+++ b/release-notes/logstash-output-opensearch-release-notes-next.md
@@ -1,9 +1,10 @@
-## Version 2.0.3 Release Notes
+## Version 2.1.0 Release Notes
 
 Compatible with OpenSearch 1.3+, 2.0+
 
 ### Bug Fixes
 
+* Install against most recent versions of logstash by building with [aws-sdk-core](https://rubygems.org/gems/aws-sdk-core). (#267)
 * Fix warning retrieving cluster UUID with Amazon OpenSearch Serverless (#237)
 
 ### Documentation


### PR DESCRIPTION
### Description
Builds opensearch plugin that can be deployed against the more recent versions of logstash.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has documentation added
- [ ] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Solves this:
```
root@625ca0aeeae7:/usr/share/logstash# DEBUG=1 bin/logstash-plugin install file:///usr/share/logstash/logstash-integration-aws-0.1.0.pre.gem.zip
Using bundled JDK: /usr/share/logstash/jdk
Processing jvm.options file at `/usr/share/logstash/config/jvm.options`
Appending jvm options from environment LS_JAVA_OPTS
Using GEM_HOME=/usr/share/logstash/vendor/bundle/jruby/3.1.0
Using GEM_PATH=/usr/share/logstash/vendor/bundle/jruby/3.1.0
DEBUG: exec /usr/share/logstash/vendor/jruby/bin/jruby /usr/share/logstash/lib/pluginmanager/main.rb install file:///usr/share/logstash/logstash-integration-aws-0.1.0.pre.gem.zip
Local file: /usr/share/logstash/logstash-integration-aws-0.1.0.pre.gem.zip
Installing with strategy: LogStash::PluginManager::PackInstaller::Local
Installing file: /usr/share/logstash/logstash-integration-aws-0.1.0.pre.gem.zip
Pack uncompressed to /tmp/studtmp-e7f0ee38a2427ecc981c9fecfe62f873854f97aa0c9df5916e21076d5fa3
Installing, logstash-integration-aws, version: 0.1.0.pre file: /tmp/studtmp-e7f0ee38a2427ecc981c9fecfe62f873854f97aa0c9df5916e21076d5fa3/logstash-integration-aws-0.1.0.pre.gem
Found changes from the lockfile, re-resolving dependencies because the dependencies in your gemfile changed, you added a new platform to your gemfile
Resolving dependencies.....................................
Install successful
root@625ca0aeeae7:/usr/share/logstash# DEBUG=1 bin/logstash-plugin install file:///usr/share/logstash/logstash-output-opensearch-2.0.3-java.gem.zip
Using bundled JDK: /usr/share/logstash/jdk
Processing jvm.options file at `/usr/share/logstash/config/jvm.options`
Appending jvm options from environment LS_JAVA_OPTS
Using GEM_HOME=/usr/share/logstash/vendor/bundle/jruby/3.1.0
Using GEM_PATH=/usr/share/logstash/vendor/bundle/jruby/3.1.0
DEBUG: exec /usr/share/logstash/vendor/jruby/bin/jruby /usr/share/logstash/lib/pluginmanager/main.rb install file:///usr/share/logstash/logstash-output-opensearch-2.0.3-java.gem.zip
Local file: /usr/share/logstash/logstash-output-opensearch-2.0.3-java.gem.zip
Installing with strategy: LogStash::PluginManager::PackInstaller::Local
Installing file: /usr/share/logstash/logstash-output-opensearch-2.0.3-java.gem.zip
Pack uncompressed to /tmp/studtmp-85e6cce49abf76bf6b4104545d318070d64e86c8fbeb3e51d8c93029ab7a
Installing, logstash-output-opensearch, version: 2.0.3 file: /tmp/studtmp-85e6cce49abf76bf6b4104545d318070d64e86c8fbeb3e51d8c93029ab7a/dist/logstash-output-opensearch-2.0.3-java.gem
Found changes from the lockfile, re-resolving dependencies because the dependencies in your gemfile changed, you added a new platform to your gemfile
Resolving dependencies......................................................................................
Bundler::VersionConflict: Could not find gem 'aws-sdk (~> 3)', which is required by gem 'logstash-output-opensearch (= 2.0.3)', in any of the sources.
            start at /usr/share/logstash/vendor/jruby/lib/ruby/stdlib/bundler/resolver.rb:53
          resolve at /usr/share/logstash/vendor/jruby/lib/ruby/stdlib/bundler/definition.rb:279
      add_sources at /usr/share/logstash/vendor/jruby/lib/ruby/stdlib/bundler/lockfile_generator.rb:38
             each at org/jruby/RubyArray.java:1981
  each_with_index at org/jruby/RubyEnumerable.java:1214
      add_sources at /usr/share/logstash/vendor/jruby/lib/ruby/stdlib/bundler/lockfile_generator.rb:31
        generate! at /usr/share/logstash/vendor/jruby/lib/ruby/stdlib/bundler/lockfile_generator.rb:19
         generate at /usr/share/logstash/vendor/jruby/lib/ruby/stdlib/bundler/lockfile_generator.rb:15
          to_lock at /usr/share/logstash/vendor/jruby/lib/ruby/stdlib/bundler/definition.rb:344
             lock at /usr/share/logstash/vendor/jruby/lib/ruby/stdlib/bundler/definition.rb:294
           inject at /usr/share/logstash/lib/pluginmanager/bundler/logstash_injector.rb:99
        temporary at /usr/share/logstash/vendor/jruby/lib/ruby/stdlib/bundler/settings.rb:131
           inject at /usr/share/logstash/lib/pluginmanager/bundler/logstash_injector.rb:76
          inject! at /usr/share/logstash/lib/pluginmanager/bundler/logstash_injector.rb:59
            chdir at org/jruby/RubyDir.java:472
          inject! at /usr/share/logstash/lib/pluginmanager/bundler/logstash_injector.rb:58
          execute at /usr/share/logstash/lib/pluginmanager/pack_installer/local.rb:57
          execute at /usr/share/logstash/lib/pluginmanager/install.rb:48
              run at /usr/share/logstash/vendor/bundle/jruby/3.1.0/gems/clamp-1.0.1/lib/clamp/command.rb:68
          execute at /usr/share/logstash/vendor/bundle/jruby/3.1.0/gems/clamp-1.0.1/lib/clamp/subcommand/execution.rb:11
              run at /usr/share/logstash/vendor/bundle/jruby/3.1.0/gems/clamp-1.0.1/lib/clamp/command.rb:68
              run at /usr/share/logstash/vendor/bundle/jruby/3.1.0/gems/clamp-1.0.1/lib/clamp/command.rb:133
           <main> at /usr/share/logstash/lib/pluginmanager/main.rb:64
Bundler::Molinillo::VersionConflict: Unable to satisfy the following requirements:

- `aws-sdk (~> 3)` required by `logstash-output-opensearch (2.0.3) (java)`
  raise_error_unless_state at /usr/share/logstash/vendor/jruby/lib/ruby/stdlib/bundler/vendor/molinillo/lib/molinillo/resolution.rb:317
       unwind_for_conflict at /usr/share/logstash/vendor/jruby/lib/ruby/stdlib/bundler/vendor/molinillo/lib/molinillo/resolution.rb:299
                       tap at <internal:uri:classloader:/jruby/kernel/kernel.rb>:19
       unwind_for_conflict at /usr/share/logstash/vendor/jruby/lib/ruby/stdlib/bundler/vendor/molinillo/lib/molinillo/resolution.rb:297
     process_topmost_state at /usr/share/logstash/vendor/jruby/lib/ruby/stdlib/bundler/vendor/molinillo/lib/molinillo/resolution.rb:257
                   resolve at /usr/share/logstash/vendor/jruby/lib/ruby/stdlib/bundler/vendor/molinillo/lib/molinillo/resolution.rb:182
                   resolve at /usr/share/logstash/vendor/jruby/lib/ruby/stdlib/bundler/vendor/molinillo/lib/molinillo/resolver.rb:43
                     start at /usr/share/logstash/vendor/jruby/lib/ruby/stdlib/bundler/resolver.rb:32
                   resolve at /usr/share/logstash/vendor/jruby/lib/ruby/stdlib/bundler/definition.rb:279
               add_sources at /usr/share/logstash/vendor/jruby/lib/ruby/stdlib/bundler/lockfile_generator.rb:38
                      each at org/jruby/RubyArray.java:1981
           each_with_index at org/jruby/RubyEnumerable.java:1214
               add_sources at /usr/share/logstash/vendor/jruby/lib/ruby/stdlib/bundler/lockfile_generator.rb:31
                 generate! at /usr/share/logstash/vendor/jruby/lib/ruby/stdlib/bundler/lockfile_generator.rb:19
                  generate at /usr/share/logstash/vendor/jruby/lib/ruby/stdlib/bundler/lockfile_generator.rb:15
                   to_lock at /usr/share/logstash/vendor/jruby/lib/ruby/stdlib/bundler/definition.rb:344
                      lock at /usr/share/logstash/vendor/jruby/lib/ruby/stdlib/bundler/definition.rb:294
                    inject at /usr/share/logstash/lib/pluginmanager/bundler/logstash_injector.rb:99
                 temporary at /usr/share/logstash/vendor/jruby/lib/ruby/stdlib/bundler/settings.rb:131
                    inject at /usr/share/logstash/lib/pluginmanager/bundler/logstash_injector.rb:76
                   inject! at /usr/share/logstash/lib/pluginmanager/bundler/logstash_injector.rb:59
                     chdir at org/jruby/RubyDir.java:472
                   inject! at /usr/share/logstash/lib/pluginmanager/bundler/logstash_injector.rb:58
                   execute at /usr/share/logstash/lib/pluginmanager/pack_installer/local.rb:57
                   execute at /usr/share/logstash/lib/pluginmanager/install.rb:48
                       run at /usr/share/logstash/vendor/bundle/jruby/3.1.0/gems/clamp-1.0.1/lib/clamp/command.rb:68
                   execute at /usr/share/logstash/vendor/bundle/jruby/3.1.0/gems/clamp-1.0.1/lib/clamp/subcommand/execution.rb:11
                       run at /usr/share/logstash/vendor/bundle/jruby/3.1.0/gems/clamp-1.0.1/lib/clamp/command.rb:68
                       run at /usr/share/logstash/vendor/bundle/jruby/3.1.0/gems/clamp-1.0.1/lib/clamp/command.rb:133
                    <main> at /usr/share/logstash/lib/pluginmanager/main.rb:64
```