### PR TITLE
Fix: use encoding.ascii_compatible? in minimum_encoding_for to handle ASCII-8BIT (gzip) bodies with aws_iam auth

### DIFF
--- a/lib/logstash/outputs/opensearch/http_client/manticore_adapter.rb
+++ b/lib/logstash/outputs/opensearch/http_client/manticore_adapter.rb
@@ -190,7 +190,7 @@ module LogStash; module Outputs; class OpenSearch; class HttpClient;
     ISO_8859_1 = "ISO-8859-1".freeze
 
     def minimum_encoding_for(string)
-      if string.ascii_only?
+      if string.encoding.ascii_compatible?
         ISO_8859_1
       else
         string.encoding.to_s

--- a/spec/unit/outputs/opensearch/http_client/manticore_adapter_spec.rb
+++ b/spec/unit/outputs/opensearch/http_client/manticore_adapter_spec.rb
@@ -144,6 +144,26 @@ describe LogStash::Outputs::OpenSearch::HttpClient::ManticoreAdapter do
         ).and_return resp
         subject.perform_request(uri, :post, "/", { body: encoded_body })
       end
+
+      it 'handles ASCII-8BIT body (e.g. gzip-compressed) without raising UnsupportedCharsetException' do
+        require 'zlib'
+        require 'stringio'
+        io = StringIO.new
+        io.set_encoding "BINARY"
+        gz = Zlib::GzipWriter.new(io)
+        gz.write("hello world\n")
+        gz.close
+        gzip_body = io.string
+
+        expect(gzip_body.encoding.to_s).to eq("ASCII-8BIT")
+        expect(gzip_body.ascii_only?).to be false
+
+        expect_any_instance_of(Aws::Sigv4::Signer).to receive(:sign_request).and_return(
+          double(headers: {})
+        )
+        expect(subject.manticore).to receive(:post).and_return resp
+        expect { subject.perform_request(uri, :post, "/", { body: gzip_body }) }.not_to raise_error
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes #293

When `http_compression => true` is used together with `auth_type => { type => 'aws_iam' }`, every bulk request silently fails with a Java `UnsupportedCharsetException`, dropping all documents.

## Root Cause

`http_client.rb` sets the `StringIO` encoding to `"BINARY"` before writing through the `GzipWriter`:

```ruby
def gzip_writer(io)
  io.set_encoding "BINARY"   # body_stream.string will be ASCII-8BIT
  Zlib::GzipWriter.new(io, ...)
end
```

The resulting body string has encoding `ASCII-8BIT`. In `minimum_encoding_for`, the old condition `string.ascii_only?` returns `false` for binary data (gzip bytes are not all-ASCII), so the method falls through to `string.encoding.to_s`, returning `"ASCII-8BIT"`. That name is an MRI Ruby internal alias — not a valid IANA charset — so Java's `StringEntity` raises `UnsupportedCharsetException` before the request is sent.

```
# Before fix
body.encoding      # => ASCII-8BIT
body.ascii_only?   # => false  ← falls to bad branch
body.encoding.to_s # => "ASCII-8BIT"  ← not a valid IANA charset for Java
# → StringEntity raises UnsupportedCharsetException
```

## Fix

Use `encoding.ascii_compatible?` instead of `ascii_only?`. `ASCII-8BIT` reports `ascii_compatible? == true`, so the method returns `"ISO-8859-1"` — a valid IANA charset that is byte-preserving for the full 0x00–0xFF range, preserving the gzip payload exactly for Sigv4 signing.

```ruby
# After fix
body.encoding.ascii_compatible?  # => true  ← correct branch
# → returns "ISO-8859-1", StringEntity constructs successfully
```

## Changes

- `lib/logstash/outputs/opensearch/http_client/manticore_adapter.rb`: one-line fix, `ascii_only?` → `encoding.ascii_compatible?`
- `spec/unit/outputs/opensearch/http_client/manticore_adapter_spec.rb`: new test case that constructs a real gzip body (ASCII-8BIT encoding) and asserts `perform_request` does not raise